### PR TITLE
Add initial WeddingTableMatch package with models, solver stub, and CLI

### DIFF
--- a/WeddingTableMatch/__init__.py
+++ b/WeddingTableMatch/__init__.py
@@ -1,0 +1,5 @@
+"""WeddingTableMatch package."""
+
+from .models import Guest, Table, Relationship
+
+__all__ = ["Guest", "Table", "Relationship"]

--- a/WeddingTableMatch/cli.py
+++ b/WeddingTableMatch/cli.py
@@ -1,0 +1,10 @@
+"""Command-line interface for WeddingTableMatch."""
+
+
+def main() -> None:
+    """Entry point for the CLI."""
+    print("WeddingTableMatch CLI ready")
+
+
+if __name__ == "__main__":
+    main()

--- a/WeddingTableMatch/models.py
+++ b/WeddingTableMatch/models.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Guest:
+    """Represents a wedding guest."""
+    name: str
+    single: bool
+    gender_identity: str
+    interested_in: List[str]
+    min_known_neighbors: int
+    min_unknown_neighbors: int
+
+
+@dataclass
+class Table:
+    """Represents a table at the wedding."""
+    name: str
+    capacity: int
+
+
+@dataclass
+class Relationship:
+    """Represents a relationship between two guests."""
+    a: str
+    b: str
+    relation: str
+    strength: int

--- a/WeddingTableMatch/solver.py
+++ b/WeddingTableMatch/solver.py
@@ -1,0 +1,13 @@
+"""Solver stub for future OR-Tools implementation."""
+
+
+class SeatingModel:
+    """A seating model that will use OR-Tools to solve table assignments."""
+
+    def build(self):
+        """Build the optimization model."""
+        raise NotImplementedError
+
+    def solve(self):
+        """Solve the optimization model."""
+        raise NotImplementedError

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,19 @@
+import pathlib
+import sys
+
+# Ensure package root is on sys.path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from WeddingTableMatch import Guest
+
+
+def test_guest_instantiation():
+    guest = Guest(
+        name="Alex",
+        single=True,
+        gender_identity="nonbinary",
+        interested_in=["any"],
+        min_known_neighbors=0,
+        min_unknown_neighbors=0,
+    )
+    assert guest.name == "Alex"


### PR DESCRIPTION
## Summary
- implement dataclasses for Guest, Table, and Relationship
- add SeatingModel solver stub with build and solve placeholders
- add CLI entry point and simple unit test for Guest instantiation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c63f7ef3c0832a831cb59870230a0f